### PR TITLE
Autofocus the "close" button for error modal

### DIFF
--- a/components/OperationOutcomeOverlay.vue
+++ b/components/OperationOutcomeOverlay.vue
@@ -70,7 +70,7 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer />
-        <v-btn @click="close">Ok</v-btn>
+        <v-btn ref="close" @click="close">Ok</v-btn>
         <v-spacer />
       </v-card-actions>
     </v-card>
@@ -141,6 +141,9 @@ export default Vue.extend({
     saveOutcome: Object as PropType<fhir4.OperationOutcome>,
     showOutcome: Boolean,
     popupWhenErrors: { type: Boolean, required: false, default: true }
+  },
+  mounted() {
+    this.$refs.close.$el.focus()
   },
   methods: {
     hideIssue(issue: fhir4.OperationOutcomeIssue): boolean {


### PR DESCRIPTION
There may be a better way to do this, so it applies for all modals or in all contexts. But the basic feature request is: let me just hit "space bar" to ack errors if they pop up.