### PR TITLE
Minor cleanups

### DIFF
--- a/components/ParseTreeTab.vue
+++ b/components/ParseTreeTab.vue
@@ -120,6 +120,12 @@ import fhirpath_r4_model from "fhirpath/fhir-context/r4";
 import fhirpath_r5_model from "fhirpath/fhir-context/r5";
 import { UndesirableEffectFrequencyCodeType } from "@fhir-typescript/r4b-core/dist/valueSetCodes";
 
+// Workaround to include the definition of the parse function
+// (which is actually there, just not in the definition)
+declare module "fhirpath" {
+  export function parse(expression: string): any;
+}
+
 export interface JsonNode {
   id?: string;
   ExpressionType: string;
@@ -380,11 +386,7 @@ export default class ParseTreeTab extends Vue {
     this.parseErrorMessage = undefined;
 
     try {
-      var ast: fpjsNode = fhirpath.parse(
-        expression,
-        context,
-        fhirpath_r4_model
-      );
+      var ast: fpjsNode = fhirpath.parse(expression);
       if (ast.children && ast.children.length > 0) {
         const node = ConvertFhirPathJsToAst(ast);
         this.astTree =

--- a/components/ParseTreeTab.vue
+++ b/components/ParseTreeTab.vue
@@ -118,7 +118,6 @@ import { Component, Vue } from "vue-property-decorator";
 import fhirpath from "fhirpath";
 import fhirpath_r4_model from "fhirpath/fhir-context/r4";
 import fhirpath_r5_model from "fhirpath/fhir-context/r5";
-import { UndesirableEffectFrequencyCodeType } from "@fhir-typescript/r4b-core/dist/valueSetCodes";
 
 // Workaround to include the definition of the parse function
 // (which is actually there, just not in the definition)

--- a/components/ParseTreeTab.vue
+++ b/components/ParseTreeTab.vue
@@ -1,0 +1,425 @@
+<template>
+  <div>
+    <v-alert v-show="parseErrorMessage" outlined border="left" type="error">{{
+      parseErrorMessage
+    }}</v-alert>
+    <v-treeview
+      :items="astInverted ? astInvertedTree : astTree"
+      :open="astInverted ? astOpenInverted : astOpen"
+      activatable
+      :dense="true"
+      item-key="id"
+      item-text="Name"
+      item-children="Arguments"
+      open-on-click
+    >
+      <template v-slot:prepend="{ item }">
+        <v-icon
+          v-if="item.ReturnType && item.ReturnType.length == 0"
+          color="red"
+        >
+          mdi-alert-octagon
+        </v-icon>
+      </template>
+      <template v-slot:label="{ item }">
+        <template v-if="item.ExpressionType === 'FunctionCallExpression'">
+          .{{ item.Name }}(<template
+            v-if="item.Arguments && item.Arguments.length > 0"
+            >...</template
+          >)
+          <span
+            style="color: grey"
+            v-if="item.ReturnType && item.ReturnType.length > 0"
+            >: {{ item.ReturnType }}</span
+          >
+        </template>
+        <template v-else-if="item.ExpressionType === 'ConstantExpression'">
+          <span style="color: #a31515">'{{ item.Name }}'</span>
+          <span
+            style="color: grey"
+            v-if="item.ReturnType && item.ReturnType.length > 0"
+            >: {{ item.ReturnType }}</span
+          >
+        </template>
+        <template v-else-if="item.ExpressionType === 'ChildExpression'">
+          .<span style="color: #318495; font-weight: bold">{{
+            item.Name
+          }}</span>
+          <span
+            style="color: grey"
+            v-if="item.ReturnType && item.ReturnType.length > 0"
+            >: {{ item.ReturnType }}</span
+          >
+        </template>
+        <template v-else-if="item.ExpressionType === 'VariableRefExpression'">
+          <span style="color: #b255a5; font-weight: bold"
+            >%{{ item.Name }}</span
+          >
+          <span
+            style="color: grey"
+            v-if="item.ReturnType && item.ReturnType.length > 0"
+            >: {{ item.ReturnType }}</span
+          >
+        </template>
+        <template
+          v-else-if="
+            item.ExpressionType === 'AxisExpression' &&
+            item.Name === 'builtin.this'
+          "
+        >
+          <span style="color: #0000ff; font-weight: bold">$this</span>
+          <span
+            style="color: grey"
+            v-if="item.ReturnType && item.ReturnType.length > 0"
+            >: {{ item.ReturnType }}</span
+          >
+        </template>
+        <template
+          v-else-if="
+            item.ExpressionType === 'AxisExpression' &&
+            item.Name === 'builtin.that'
+          "
+        >
+          <span style="color: #0000ff">Expression Scope</span>
+          <span
+            style="color: grey"
+            v-if="item.ReturnType && item.ReturnType.length > 0"
+            >: {{ item.ReturnType }}</span
+          >
+        </template>
+        <template v-else>
+          {{ item.Name }}
+          <span
+            style="color: grey"
+            v-if="item.ReturnType && item.ReturnType.length > 0"
+            >: {{ item.ReturnType }}</span
+          >
+          ({{ item.ExpressionType }})
+        </template>
+        <template
+          v-if="
+            (!item.ReturnType || item.ReturnType.length == 0) &&
+            warnMissingTypeCalc
+          "
+        >
+          <i><b>(no return type calculated)</b></i>
+        </template>
+        <!-- <template>
+        {{ item.id }}
+      </template> -->
+      </template>
+    </v-treeview>
+    <v-checkbox v-model="astInverted" label="Inverted Tree"></v-checkbox>
+  </div>
+</template>  
+    
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import fhirpath from "fhirpath";
+import fhirpath_r4_model from "fhirpath/fhir-context/r4";
+import fhirpath_r5_model from "fhirpath/fhir-context/r5";
+import { UndesirableEffectFrequencyCodeType } from "@fhir-typescript/r4b-core/dist/valueSetCodes";
+
+export interface JsonNode {
+  id?: string;
+  ExpressionType: string;
+  Name: string;
+  Arguments?: JsonNode[];
+  ReturnType?: string;
+}
+
+interface fpjsNode {
+  children?: fpjsNode[];
+  terminalNodeText?: string[];
+  text: string;
+  type: string;
+}
+
+export function AllocateNodeIds(ast: JsonNode, startAt: number = 0): number {
+  ast.id = startAt.toString();
+  startAt++;
+  if (ast.Arguments && ast.Arguments.length > 0) {
+    return AllocateNodeCollectionIds(ast.Arguments, startAt);
+  }
+  return startAt;
+}
+
+export function AllocateNodeCollectionIds(
+  ast: JsonNode[],
+  startAt: number = 0
+): number {
+  ast.forEach((element) => {
+    startAt = AllocateNodeIds(element, startAt);
+  });
+  return startAt;
+}
+
+export function InvertTree(ast: JsonNode): JsonNode[] {
+  let rootItem: JsonNode = {
+    ExpressionType: ast.ExpressionType,
+    Name: ast.Name,
+    Arguments: [],
+    ReturnType: ast.ReturnType,
+  };
+
+  let result: JsonNode[] = [];
+  if (ast.Arguments && ast.Arguments.length > 0) {
+    const focus = InvertTree(ast.Arguments[0]);
+    result.push(...focus);
+    if (ast.Arguments?.length > 1) {
+      ast.Arguments.forEach((element, index) => {
+        if (index > 0) {
+          const elementArgs = InvertTree(element);
+          rootItem.Arguments?.push(...elementArgs);
+        }
+      });
+    } else {
+      delete rootItem.Arguments;
+    }
+  }
+  result.push(rootItem);
+  return result;
+}
+
+function ConvertFhirPathJsToAst(ast: fpjsNode): JsonNode {
+  let result: JsonNode = {
+    ExpressionType: ast.type,
+    Name: ast.terminalNodeText ? ast.terminalNodeText[0] : "", //text,
+    Arguments: [],
+    ReturnType: "",
+  };
+
+  // convert all the child nodes
+  if (ast.children) {
+    ast.children.forEach((element: fpjsNode) => {
+      result.Arguments?.push(ConvertFhirPathJsToAst(element));
+    });
+  } else {
+    delete result.Arguments;
+  }
+
+  // Populate the Type for known types
+  switch (result.ExpressionType) {
+    case "StringLiteral":
+      result.ReturnType = "string";
+      result.ExpressionType = "ConstantExpression";
+      result.Name = result.Name.substring(1, result.Name.length - 1);
+      break;
+    case "BooleanLiteral":
+      result.ReturnType = "boolean";
+      result.ExpressionType = "ConstantExpression";
+      break;
+    case "QuantityLiteral":
+      result.ReturnType = "Quantity";
+      result.ExpressionType = "ConstantExpression";
+      if (result.Arguments && result.Arguments.length > 0) {
+        result.Name = result.Arguments[0].Name;
+      }
+      delete result.Arguments;
+      return result;
+      break;
+    case "DateTimeLiteral":
+      result.ReturnType = "dateTime";
+      result.ExpressionType = "ConstantExpression";
+      result.Name = result.Name.substring(1);
+      break;
+    case "TimeLiteral":
+      result.ReturnType = "time";
+      result.ExpressionType = "ConstantExpression";
+      result.Name = result.Name.substring(2);
+      break;
+    case "NumberLiteral":
+      result.ReturnType = "Number (decimal or integer)";
+      result.ExpressionType = "ConstantExpression";
+      break;
+  }
+
+  // Short circuit some of the AST that is not useful to display
+  if (
+    result.Arguments?.length == 1 &&
+    result.ExpressionType == "FunctionInvocation"
+  ) {
+    return result.Arguments[0];
+  }
+  if (result.Arguments?.length == 1 && result.ExpressionType == "Quantity") {
+    result.Name = result.Name + " " + result.Arguments[0].Name;
+    delete result.Arguments;
+    return result;
+  }
+  if (result.Arguments?.length == 1 && result.ExpressionType == "Unit") {
+    return result.Arguments[0];
+  }
+  if (result.Arguments?.length == 1 && result.ExpressionType == "LiteralTerm") {
+    return result.Arguments[0];
+  }
+  if (
+    result.Arguments?.length == 1 &&
+    result.ExpressionType == "TermExpression"
+  ) {
+    return result.Arguments[0];
+  }
+  if (
+    result.Arguments?.length == 1 &&
+    result.ExpressionType == "ExternalConstantTerm"
+  ) {
+    return result.Arguments[0];
+  }
+
+  if (
+    result.ExpressionType == "MemberInvocation" &&
+    result.Arguments &&
+    result.Arguments.length === 1 &&
+    result.Arguments[0].ExpressionType == "Identifier"
+  ) {
+    result.ExpressionType = "ChildExpression";
+    result.Name = result.Arguments[0].Name ?? "";
+    delete result.Arguments;
+  }
+
+  if (
+    result.ExpressionType == "ExternalConstant" &&
+    result.Arguments &&
+    result.Arguments.length === 1 &&
+    result.Arguments[0].ExpressionType == "Identifier"
+  ) {
+    result.ExpressionType = "VariableRefExpression";
+    result.Name = result.Arguments[0].Name ?? "";
+    delete result.Arguments;
+  }
+
+  // restructure the function call part of the tree
+  if (
+    result.ExpressionType == "Functn" &&
+    result.Arguments &&
+    result.Arguments.length === 2 &&
+    result.Arguments[0].ExpressionType == "Identifier" &&
+    result.Arguments[1].ExpressionType == "ParamList"
+  ) {
+    result.ExpressionType = "FunctionCallExpression";
+    result.Name = result.Arguments[0].Name ?? "";
+    result.Arguments = result.Arguments[1].Arguments;
+  }
+  if (
+    result.ExpressionType == "Functn" &&
+    result.Arguments &&
+    result.Arguments.length === 1 &&
+    result.Arguments[0].ExpressionType == "Identifier"
+  ) {
+    result.ExpressionType = "FunctionCallExpression";
+    result.Name = result.Arguments[0].Name ?? "";
+    delete result.Arguments;
+  }
+
+  if (
+    result.Arguments?.length == 1 &&
+    result.ExpressionType == "InvocationTerm" // this is the "scoping node"
+  ) {
+    // inject the scoping node into the tree
+    let scopeNode: JsonNode = {
+      ExpressionType: "AxisExpression",
+      Name: "builtin.that",
+      Arguments: [],
+      ReturnType: "",
+    };
+    if (result.Arguments[0].Arguments)
+      result.Arguments[0].Arguments?.unshift(scopeNode);
+    else result.Arguments[0].Arguments = [scopeNode];
+    return result.Arguments[0];
+  }
+
+  // -----------
+  if (
+    result.ExpressionType == "InvocationExpression" &&
+    result.Arguments &&
+    result.Arguments?.length > 1
+  ) {
+    if (result.Arguments[1].Arguments)
+      result.Arguments[1].Arguments?.unshift(result.Arguments[0]);
+    else result.Arguments[1].Arguments = [result.Arguments[0]];
+    return result.Arguments[1];
+  }
+  return result;
+}
+
+@Component
+export default class ParseTreeTab extends Vue {
+  astTree: JsonNode[] = [];
+  astInvertedTree: JsonNode[] = [];
+  astOpen: string[] = [];
+  astOpenInverted: string[] = [];
+  public astInverted: boolean = false;
+  public warnMissingTypeCalc: boolean = false;
+  public parseErrorMessage: string | undefined = "";
+
+  public clearDisplay(message: string | undefined = undefined) {
+    this.astTree = [];
+    this.astInvertedTree = [];
+    this.astOpen = [];
+    this.astOpenInverted = [];
+    this.parseErrorMessage = message;
+  }
+  public displayTree(node: JsonNode) {
+    this.warnMissingTypeCalc = true;
+    this.parseErrorMessage = undefined;
+
+    this.astTree = [node];
+    var lastId = AllocateNodeCollectionIds(this.astTree);
+    for (let i = 0; i < lastId; i++) {
+      this.astOpen.push(i.toString());
+    }
+
+    this.astInvertedTree = InvertTree(this.astTree[0]);
+    lastId = AllocateNodeCollectionIds(this.astInvertedTree);
+    for (let i = 0; i < lastId; i++) {
+      this.astOpenInverted.push(i.toString());
+    }
+  }
+
+  public displayTreeForExpression(context: string, expression: string) {
+    this.warnMissingTypeCalc = false;
+    this.parseErrorMessage = undefined;
+
+    try {
+      var ast: fpjsNode = fhirpath.parse(
+        expression,
+        context,
+        fhirpath_r4_model
+      );
+      if (ast.children && ast.children.length > 0) {
+        const node = ConvertFhirPathJsToAst(ast);
+        this.astTree =
+          (node.Arguments ? node.Arguments[0].Arguments : []) ?? [];
+        var lastId = AllocateNodeCollectionIds(this.astTree);
+        for (let i = 0; i < lastId; i++) {
+          this.astOpen.push(i.toString());
+        }
+
+        this.astInvertedTree = InvertTree(this.astTree[0]);
+        lastId = AllocateNodeCollectionIds(this.astInvertedTree);
+        for (let i = 0; i < lastId; i++) {
+          this.astOpenInverted.push(i.toString());
+        }
+        // console.log("raw:", JSON.stringify(ast, null, 2));
+        console.log("AST:", JSON.stringify(this.astTree, null, 2));
+        // console.log("Inv AST:", JSON.stringify(this.astInvertedTree, null, 2));
+
+        for (let i = 0; i < lastId; i++) {
+          this.astOpen.push(i.toString());
+          this.astOpenInverted.push(i.toString());
+        }
+      }
+    } catch (err) {
+      console.log(err);
+      this.parseErrorMessage = err?.message;
+    }
+  }
+
+  scrollToBottom() {
+    this.$nextTick(() => {
+      const container = this.$refs.messagesContainer as HTMLElement;
+      container.scrollTop = container.scrollHeight;
+    });
+  }
+}
+</script>  
+  

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -59,7 +59,7 @@ export default {
 
   // https://github.com/nuxt-community/applicationinsights-module
   appInsights: {
-    instrumentationKey: '2a417deb-a0e7-4737-83ca-947e21b66dd0' //  your project's Instrumentation Key here
+    instrumentationKey: '6734f815-da7c-4b6d-b532-90d1421dd2b8' //  your project's Instrumentation Key here
   },
 
   // Build Configuration: https://go.nuxtjs.dev/config-build

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@azure/openai": "^1.0.0-beta.2",
-        "@fhir-typescript/r4b-core": "0.0.12-beta.15",
         "@nuxtjs/applicationinsights": "^1.2.2",
         "@types/ace": "0.0.48",
         "@types/fhir": "^0.0.36",
@@ -3745,11 +3744,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@fhir-typescript/r4b-core": {
-      "version": "0.0.12-beta.15",
-      "resolved": "https://registry.npmjs.org/@fhir-typescript/r4b-core/-/r4b-core-0.0.12-beta.15.tgz",
-      "integrity": "sha512-wC+hYzX7L3cAFIv64ENmrOz5F/91yBeu7u4p90GMC9r5vBg4bFjURIMJaa7boSbvLlqtdu1smVUW+LqD6FHGXw=="
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.2",
@@ -27457,11 +27451,6 @@
           }
         }
       }
-    },
-    "@fhir-typescript/r4b-core": {
-      "version": "0.0.12-beta.15",
-      "resolved": "https://registry.npmjs.org/@fhir-typescript/r4b-core/-/r4b-core-0.0.12-beta.15.tgz",
-      "integrity": "sha512-wC+hYzX7L3cAFIv64ENmrOz5F/91yBeu7u4p90GMC9r5vBg4bFjURIMJaa7boSbvLlqtdu1smVUW+LqD6FHGXw=="
     },
     "@gar/promisify": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,10 @@
     "build": "nuxt build",
     "start": "nuxt start",
     "generate": "nuxt generate",
-    "dockerize": "docker build -t forms-lab ."
+    "dockerize": "docker build -t fhirpath-lab ."
   },
   "dependencies": {
     "@azure/openai": "^1.0.0-beta.2",
-    "@fhir-typescript/r4b-core": "0.0.12-beta.15",
     "@nuxtjs/applicationinsights": "^1.2.2",
     "@types/ace": "0.0.48",
     "@types/fhir": "^0.0.36",

--- a/pages/FhirMapper/index.vue
+++ b/pages/FhirMapper/index.vue
@@ -296,7 +296,6 @@ import "ace-builds/src-noconflict/mode-text";
 import "ace-builds/src-noconflict/mode-json";
 import "ace-builds/src-noconflict/theme-chrome";
 
-import { fhir } from '@fhir-typescript/r4b-core';
 import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from "lz-string";
 import { TestFhirMapData } from "~/models/testenginemodel";
 
@@ -815,29 +814,7 @@ group SetEntryData(source src: Patient, target entry)
       // reset the processing engine
       this.processedByEngine = undefined;
 
-      // Validate the test fhir resource object
       let resourceJson = this.getResourceJson();
-      if (resourceJson) {
-        let rawObj: object;
-        try {
-          rawObj = JSON.parse(resourceJson)
-          let resource: fhir.FhirResource | null = fhir.resourceFactory(rawObj);
-          if (resource) {
-            const issues: fhir.FtsIssue[] = resource.doModelValidation();
-            if (issues.length !== 0) {
-              this.saveOutcome = { resourceType: 'OperationOutcome', issue: [] }
-              this.saveOutcome?.issue.push(...issues as any);
-              this.showOutcome = true;
-            }
-          }
-        } catch (err) {
-          console.log(err);
-          this.saveOutcome = { resourceType: 'OperationOutcome', issue: [] }
-          this.saveOutcome?.issue.push({ code: 'exception', severity: 'error', details: { text: `Failed to parse the resource: ${err}` } });
-          this.showOutcome = true;
-          this.loadingData = false;
-        }
-      }
 
       // brianpos hosted service
       // default the firely SDK/brianpos service

--- a/pages/FhirMapper2/index.vue
+++ b/pages/FhirMapper2/index.vue
@@ -393,7 +393,6 @@ import "ace-builds/src-noconflict/mode-text";
 import "ace-builds/src-noconflict/mode-json";
 import "ace-builds/src-noconflict/theme-chrome";
 
-import { fhir } from '@fhir-typescript/r4b-core';
 import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from "lz-string";
 import { TestFhirMapData } from "~/models/testenginemodel";
 
@@ -940,29 +939,7 @@ group SetEntryData(source src: Patient, target entry)
       // reset the processing engine
       this.processedByEngine = undefined;
 
-      // Validate the test fhir resource object
       let resourceJson = this.getResourceJson();
-      if (resourceJson) {
-        let rawObj: object;
-        try {
-          rawObj = JSON.parse(resourceJson)
-          let resource: fhir.FhirResource | null = fhir.resourceFactory(rawObj);
-          if (resource) {
-            const issues: fhir.FtsIssue[] = resource.doModelValidation();
-            if (issues.length !== 0) {
-              this.saveOutcome = { resourceType: 'OperationOutcome', issue: [] }
-              this.saveOutcome?.issue.push(...issues as any);
-              this.showOutcome = true;
-            }
-          }
-        } catch (err) {
-          console.log(err);
-          this.saveOutcome = { resourceType: 'OperationOutcome', issue: [] }
-          this.saveOutcome?.issue.push({ code: 'exception', severity: 'error', details: { text: `Failed to parse the resource: ${err}` } });
-          this.showOutcome = true;
-          this.loadingData = false;
-        }
-      }
 
       // brianpos hosted service
       // default the firely SDK/brianpos service

--- a/pages/FhirPath/index.vue
+++ b/pages/FhirPath/index.vue
@@ -1939,7 +1939,7 @@ export default Vue.extend<FhirPathData, IFhirPathMethods, IFhirPathComputed, IFh
       this.saveLastUsedParameters(false);
 
       if (this.selectedEngine == "fhirpath.js") {
-        astTab2.displayTreeForExpression(this.getContextExpression() ?? '', this.getFhirpathExpression() ?? '');
+        astTab2?.displayTreeForExpression(this.getContextExpression() ?? '', this.getFhirpathExpression() ?? '');
         await this.evaluateExpressionUsingFhirpathJs();
         this.saveLastUsedParameters(true);
         if (this.prevFocus){
@@ -1949,7 +1949,7 @@ export default Vue.extend<FhirPathData, IFhirPathMethods, IFhirPathComputed, IFh
       }
 
       if (this.selectedEngine == "fhirpath.js (R5)") {
-        astTab2.displayTreeForExpression(this.getContextExpression() ?? '', this.getFhirpathExpression() ?? '');
+        astTab2?.displayTreeForExpression(this.getContextExpression() ?? '', this.getFhirpathExpression() ?? '');
         await this.evaluateExpressionUsingFhirpathJsR5();
         this.saveLastUsedParameters(true);
         if (this.prevFocus){

--- a/pages/FhirPath/index.vue
+++ b/pages/FhirPath/index.vue
@@ -62,9 +62,9 @@
                 <v-icon left> mdi-file-tree </v-icon>
                 AST
               </v-tab>
-              <v-tab v-show="showAdvancedSettings" :class="chatActiveClass" v-on:click="tabClicked">
+              <v-tab v-show="showAdvancedSettings && chatEnabled" :class="chatActiveClass" v-on:click="tabClicked">
                 <v-icon left> mdi-brain </v-icon>
-                Chat
+                AI Chat
               </v-tab>
               <v-tab v-show="showAdvancedSettings" :class="debugActiveClass" v-on:click="tabClicked">
                 <v-icon left> mdi-bug-outline </v-icon>

--- a/pages/FhirPath/index.vue
+++ b/pages/FhirPath/index.vue
@@ -88,7 +88,7 @@
                         <label class="v-label theme--light bare-label">Fhirpath Expression</label>
                         <div height="85px" width="100%" ref="aceEditorExpression"></div>
                         <div class="ace_editor_footer"></div>
-                        <parse-tree-tab v-show="false" ref="astTabComponent"></parse-tree-tab>
+                        <!-- <parse-tree-tab v-show="false" ref="astTabComponent"></parse-tree-tab> -->
 
                         <div class="results">RESULTS <span class="processedBy">{{ processedByEngine }}</span></div>
                         <OperationOutcomePanel :outcome="expressionParseOutcome" @close="expressionParseOutcome = undefined" />
@@ -205,7 +205,7 @@
                 </v-scroll-x-transition>
 
                 <v-scroll-x-transition mode="out-in" :hide-on-leave="true">
-                  <div v-show="astVisible">
+                  <div v-show="astVisible" :eager="true">
                     <!-- AST abstract syntax tree -->
                     <v-card flat>
                       <v-card-text>
@@ -625,7 +625,7 @@ interface IFhirPathProps
     aceEditorDebug: HTMLDivElement,
     aceEditorResourceJson: HTMLDivElement,
     chatComponent: Chat,
-    astTabComponent: ParseTreeTab,
+    // astTabComponent: ParseTreeTab,
     astTabComponent2: ParseTreeTab,
   },
 }
@@ -961,8 +961,8 @@ export default Vue.extend<FhirPathData, IFhirPathMethods, IFhirPathComputed, IFh
           const astTab2 = this.$refs.astTabComponent2 as ParseTreeTab;
           astTab2.displayTreeForExpression(this.getContextExpression() ?? '', this.getFhirpathExpression() ?? '');
         }
-        const astTab = this.$refs.astTabComponent as ParseTreeTab;
-        astTab.displayTreeForExpression(this.getContextExpression() ?? '', this.getFhirpathExpression() ?? '');
+        // const astTab = this.$refs.astTabComponent as ParseTreeTab;
+        // astTab.displayTreeForExpression(this.getContextExpression() ?? '', this.getFhirpathExpression() ?? '');
 
         const count = session.doc.getLength();
         // accumulate the variables
@@ -1909,8 +1909,8 @@ export default Vue.extend<FhirPathData, IFhirPathMethods, IFhirPathComputed, IFh
       astTab2.clearDisplay();
       this.expressionParseOutcome = undefined;
       
-      const astTab = this.$refs.astTabComponent as ParseTreeTab;
-      astTab.displayTreeForExpression(this.getContextExpression() ?? '', this.getFhirpathExpression() ?? '');
+      // const astTab = this.$refs.astTabComponent as ParseTreeTab;
+      // astTab.displayTreeForExpression(this.getContextExpression() ?? '', this.getFhirpathExpression() ?? '');
 
       // Validate the test fhir resource object
       let resourceJson = this.getResourceJson();

--- a/pages/FhirPath/index.vue
+++ b/pages/FhirPath/index.vue
@@ -959,7 +959,7 @@ export default Vue.extend<FhirPathData, IFhirPathMethods, IFhirPathComputed, IFh
 
         if (this.selectedEngine.indexOf("fhirpath.js") != -1){
           const astTab2 = this.$refs.astTabComponent2 as ParseTreeTab;
-          astTab2.displayTreeForExpression(this.getContextExpression() ?? '', this.getFhirpathExpression() ?? '');
+          astTab2?.displayTreeForExpression(this.getContextExpression() ?? '', this.getFhirpathExpression() ?? '');
         }
         // const astTab = this.$refs.astTabComponent as ParseTreeTab;
         // astTab.displayTreeForExpression(this.getContextExpression() ?? '', this.getFhirpathExpression() ?? '');
@@ -1105,7 +1105,7 @@ export default Vue.extend<FhirPathData, IFhirPathMethods, IFhirPathComputed, IFh
                     if (part.name === 'parseDebugTree' && part.valueString) {
                       let ast: JsonNode = JSON.parse(part.valueString);
                       const astTab = this.$refs.astTabComponent2 as ParseTreeTab;
-                      astTab.displayTree(ast);
+                      astTab?.displayTree(ast);
                     }
                     if (part.name === 'debugOutcome' && part.resource) {
                       this.expressionParseOutcome = part.resource as fhir4b.OperationOutcome;
@@ -1906,7 +1906,7 @@ export default Vue.extend<FhirPathData, IFhirPathMethods, IFhirPathComputed, IFh
       // reset the processing engine
       this.processedByEngine = undefined;
       const astTab2 = this.$refs.astTabComponent2 as ParseTreeTab;
-      astTab2.clearDisplay();
+      astTab2?.clearDisplay();
       this.expressionParseOutcome = undefined;
       
       // const astTab = this.$refs.astTabComponent as ParseTreeTab;

--- a/static/config.json
+++ b/static/config.json
@@ -1,7 +1,7 @@
 {
-    "dotnet_server_downloader": "https://fhirpath-lab-net.azurewebsites.net/api/downloader",
-    "dotnet_server_r4b": "https://fhirpath-lab-net.azurewebsites.net/api/$fhirpath",
-    "dotnet_server_r5": "https://fhirpath-lab-net.azurewebsites.net/api/$fhirpath-r5",
+    "dotnet_server_downloader": "https://fhirpath-lab-dotnet2.azurewebsites.net/api/downloader",
+    "dotnet_server_r4b": "https://fhirpath-lab-dotnet2.azurewebsites.net/api/$fhirpath",
+    "dotnet_server_r5": "https://fhirpath-lab-dotnet2.azurewebsites.net/api/$fhirpath-r5",
     "java_server_r4b": "https://fhirpath-lab-java2.azurewebsites.net/fhir/$fhirpath",
     "java_server_r5": "https://fhirpath-lab-java2.azurewebsites.net/fhir5/$fhirpath-r5",
     "ibm_server_r4b": "https://fhirpath-lab-java2.azurewebsites.net/fhir/$fhirpath-ibm",


### PR DESCRIPTION
* Change the deployment URL for the dotnet server engine
* Switch app insights key to new subscription
* default in a sample resource without requiring an initial sample download
* include AST for fhirpath.js implementation (without type info - for now)