### PR TITLE
Use hook to obtain focused linkId

### DIFF
--- a/components/Questionnaire/ReactRenderer.tsx
+++ b/components/Questionnaire/ReactRenderer.tsx
@@ -1,33 +1,17 @@
-
-import React, { useMemo } from 'react';
-import { SmartFormsRenderer } from "@aehrc/smart-forms-renderer";
+import React from 'react';
+import { SmartFormsRenderer, useQuestionnaireStore } from "@aehrc/smart-forms-renderer";
 
 /**
  * This component is a wrapper around the SmartFormsRenderer component that adds a focus event listener to the document.
- * @param props 
- * @returns 
+ * @param props
+ * @returns
  */
 function SmartFormsRendererWithFocus(props: any) {
+  const linkId = useQuestionnaireStore.use.focusedLinkId();
 
   React.useEffect(() => {
-    const handleClick: EventListener = (event) => {
-      const linkId = (event.currentTarget as HTMLElement).getAttribute('data-linkid');
-      if (linkId) {
-        props.onFocus && props.onFocus(linkId);
-      }
-    };
-
-    const boxes = document.querySelectorAll('[data-linkid]');
-    boxes.forEach((box) => {
-      box.addEventListener('click', handleClick);
-    });
-
-    return () => {
-      boxes.forEach((box) => {
-        box.removeEventListener('click', handleClick);
-      });
-    };
-  });
+    props.onFocus(linkId);
+  }, [linkId]);
 
   return SmartFormsRenderer(props);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@aehrc/smart-forms-renderer": "^0.16.0",
+        "@aehrc/smart-forms-renderer": "^0.17.0",
         "@azure/openai": "^1.0.0-beta.2",
         "@nuxtjs/applicationinsights": "^1.2.2",
         "@types/ace": "0.0.48",
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@aehrc/smart-forms-renderer": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@aehrc/smart-forms-renderer/-/smart-forms-renderer-0.16.0.tgz",
-      "integrity": "sha512-ZwvssSLsWq9O3BLLO+MvwqDgiGJnRxpCbGB0HyYi/+do09EIvIDRxH4HxQYsZqkoMwQ4ft+dI41Fg7w6aIN6Vg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@aehrc/smart-forms-renderer/-/smart-forms-renderer-0.17.0.tgz",
+      "integrity": "sha512-xP+YNirzROo0210AGIG1Bmw/apgzVhIJhJSx2EJqMHZ4iteEUXhksOEt55FsHTwVbgiYWhsyXxN8E1bhLAhjPA==",
       "dependencies": {
         "@iconify/react": "^4.1.1",
         "@types/fhir": "^0.0.38",
@@ -28880,9 +28880,9 @@
   },
   "dependencies": {
     "@aehrc/smart-forms-renderer": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@aehrc/smart-forms-renderer/-/smart-forms-renderer-0.16.0.tgz",
-      "integrity": "sha512-ZwvssSLsWq9O3BLLO+MvwqDgiGJnRxpCbGB0HyYi/+do09EIvIDRxH4HxQYsZqkoMwQ4ft+dI41Fg7w6aIN6Vg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@aehrc/smart-forms-renderer/-/smart-forms-renderer-0.17.0.tgz",
+      "integrity": "sha512-xP+YNirzROo0210AGIG1Bmw/apgzVhIJhJSx2EJqMHZ4iteEUXhksOEt55FsHTwVbgiYWhsyXxN8E1bhLAhjPA==",
       "requires": {
         "@iconify/react": "^4.1.1",
         "@types/fhir": "^0.0.38",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dockerize": "docker build -t fhirpath-lab ."
   },
   "dependencies": {
-    "@aehrc/smart-forms-renderer": "^0.16.0",
+    "@aehrc/smart-forms-renderer": "^0.17.0",
     "@azure/openai": "^1.0.0-beta.2",
     "@nuxtjs/applicationinsights": "^1.2.2",
     "@types/ace": "0.0.48",


### PR DESCRIPTION
Use hook to obtain focused linkId instead of using an event listener.
LinkIds can now be detected even when the form view changes (via enableWhen, switching tabs).

