### PR TITLE
Add fhir-toolbox-go as additional backend (server)

### DIFF
--- a/static/config.json
+++ b/static/config.json
@@ -32,6 +32,9 @@
 	"atomic_server_r5": "https://fhirpath.atomic-ehr.org/r5",
 	"atomic_server_r6": "https://fhirpath.atomic-ehr.org/r6",
 
+	"toolbox_go_r4": "https://fhirpath-lab-go.fly.dev/$fhirpath-r4",
+	"toolbox_go_r5": "https://fhirpath-lab-go.fly.dev/$fhirpath-r5",
+
 	"local_r4": "http://localhost:3001/fhir/$fhirpath",
 	"local_r5": "http://localhost:3001/fhir/$fhirpath-r5",
 	"local_r6": "http://localhost:3001/fhir/$fhirpath-r6"

--- a/types/fhirpath_test_engine.ts
+++ b/types/fhirpath_test_engine.ts
@@ -325,6 +325,35 @@ export let registeredEngines: { [key: string]: IFhirPathEngineDetails } = {
         supportsAST: true,
         supportsXML: false
     },
+    
+    "toolbox-go (R4)": {
+        name: "toolbox-go",
+        legacyName: "toolbox-go (R4)",
+        fhirVersion: "R4",
+        appInsightsEngineName: "toolbox-go",
+        publisher: "Damedic",
+        configSetting: "toolbox_go_r4",
+        githubRepo: "https://github.com/DAMEDIC/fhir-toolbox-go",
+        description: "A Go implementation of FHIRPath",
+        external: true,
+        supportsAST: false,
+        supportsXML: false,
+        encodeResourceJsonAsExtension: true
+    },
+    "toolbox-go (R5)": {
+        name: "toolbox-go",
+        legacyName: "toolbox-go (R5)",
+        fhirVersion: "R5",
+        appInsightsEngineName: "toolbox-go",
+        publisher: "Damedic",
+        configSetting: "toolbox_go_r5",
+        githubRepo: "https://github.com/DAMEDIC/fhir-toolbox-go",
+        description: "A Go implementation of FHIRPath",
+        external: true,
+        supportsAST: false,
+        supportsXML: false,
+        encodeResourceJsonAsExtension: true
+    },
 
     "Local (R4)": {
         name: "Localhost",


### PR DESCRIPTION
The implementation can be found here:
https://github.com/lschmierer/fhirpath-lab-go

## Status
- trace-debug and AST not supported (yet)