### PR TITLE
Adds ignixa fhirpath

### DIFF
--- a/static/config.json
+++ b/static/config.json
@@ -35,6 +35,10 @@
 	"toolbox_go_r4": "https://fhirpath-lab-go.fly.dev/$fhirpath-r4",
 	"toolbox_go_r5": "https://fhirpath-lab-go.fly.dev/$fhirpath-r5",
 
+	"ignixa_r4": "https://ignixafhirpath.azurewebsites.net/api/$fhirpath-r4",
+	"ignixa_r5": "https://ignixafhirpath.azurewebsites.net/api/$fhirpath-r5",
+	"ignixa_r6": "https://ignixafhirpath.azurewebsites.net/api/$fhirpath-r6",
+
 	"local_r4": "http://localhost:3001/fhir/$fhirpath",
 	"local_r5": "http://localhost:3001/fhir/$fhirpath-r5",
 	"local_r6": "http://localhost:3001/fhir/$fhirpath-r6"

--- a/static/config.local.json
+++ b/static/config.local.json
@@ -32,6 +32,10 @@
 	"atomic_server_r5": "https://fhirpath.atomic-ehr.org/r5",
 	"atomic_server_r6": "https://fhirpath.atomic-ehr.org/r6",
 
+	"ignixa_r4": "https://ignixafhirpath.azurewebsites.net/api/$fhirpath-r4",
+	"ignixa_r5": "https://ignixafhirpath.azurewebsites.net/api/$fhirpath-r5",
+	"ignixa_r6": "https://ignixafhirpath.azurewebsites.net/api/$fhirpath-r6",
+
 	"local_r4": "http://localhost:3001/fhir/$fhirpath",
 	"local_r5": "http://localhost:3001/fhir/$fhirpath-r5",
 	"local_r6": "http://localhost:3001/fhir/$fhirpath-r6"

--- a/types/fhirpath_test_engine.ts
+++ b/types/fhirpath_test_engine.ts
@@ -403,4 +403,43 @@ export let registeredEngines: { [key: string]: IFhirPathEngineDetails } = {
         supportsAST: true,
         supportsXML: false
     },
+    "Ignixa (R4)": {
+        name: "Ignixa",
+        legacyName: "Ignixa (R4)",
+        fhirVersion: "R4",
+        appInsightsEngineName: "Ignixa",
+        publisher: "Ignixa",
+        configSetting: "ignixa_r4",
+        githubRepo: "https://github.com/brendankowitz/ignixa-fhir",
+        description: "Ignixa FHIRPath engine",
+        external: true,
+        supportsAST: true,
+        supportsXML: false
+    },
+    "Ignixa (R5)": {
+        name: "Ignixa",
+        legacyName: "Ignixa (R5)",
+        fhirVersion: "R5",
+        appInsightsEngineName: "Ignixa",
+        publisher: "Ignixa",
+        configSetting: "ignixa_r5",
+        githubRepo: "https://github.com/brendankowitz/ignixa-fhir",
+        description: "Ignixa FHIRPath engine for FHIR R5",
+        external: true,
+        supportsAST: true,
+        supportsXML: false
+    },
+    "Ignixa (R6)": {
+        name: "Ignixa",
+        legacyName: "Ignixa (R6)",
+        fhirVersion: "R6",
+        appInsightsEngineName: "Ignixa",
+        publisher: "Ignixa",
+        configSetting: "ignixa_r6",
+        githubRepo: "https://github.com/brendankowitz/ignixa-fhir",
+        description: "Ignixa FHIRPath engine for FHIR R6",
+        external: true,
+        supportsAST: true,
+        supportsXML: false
+    },
 };


### PR DESCRIPTION
This pull request adds support for the Ignixa FHIRPath engine across FHIR versions R4, R5, and R6. The changes update configuration files to include the new Ignixa endpoints and register the Ignixa engine details in the application.

New FHIRPath engine integration:

* Added Ignixa FHIRPath engine definitions for R4, R5, and R6 to the `registeredEngines` object in `types/fhirpath_test_engine.ts`, including metadata such as name, publisher, description, and GitHub repository.

Configuration updates:

* Added Ignixa FHIRPath engine endpoints for R4, R5, and R6 to `static/config.json` and `static/config.local.json` to enable usage of the new engine in both production and local environments. [[1]](diffhunk://#diff-c9b5b86d0c26f8a7cfef75915816d853854da00a579036406682b85b78e70351R38-R41) [[2]](diffhunk://#diff-81bb4b50704107fde53e5d07a8889f2ff576a2ee25c4ab7c7db48cae600c12deR35-R38)