### PR TITLE
Add fhirpath.zig WASM engine support (R4 + R5)

### DIFF
--- a/helpers/fhirpath_api_engine.ts
+++ b/helpers/fhirpath_api_engine.ts
@@ -977,7 +977,9 @@ async function getZigEngine(): Promise<any> {
       // Dynamic import of the JS wrapper from the deployed site
       const mod = await import(/* webpackIgnore: true */ `${FHIRPATH_ZIG_BASE}/fhirpath.js`);
       const FhirPathEngine = mod.FhirPathEngine;
-      const engine = await FhirPathEngine.instantiate(`${FHIRPATH_ZIG_BASE}/fhirpath.wasm`);
+      const engine = await FhirPathEngine.instantiate({
+        wasmUrl: `${FHIRPATH_ZIG_BASE}/fhirpath.wasm`,
+      });
       return engine;
     })();
   }
@@ -988,7 +990,7 @@ async function ensureZigSchema(engine: any, fhirVersion: string): Promise<string
   const version = fhirVersion.toLowerCase();
   const schemaName = version; // "r4" or "r5"
   if (!_zigSchemasRegistered.has(schemaName)) {
-    await engine.registerSchemaFromUrl({
+    await engine.registerSchema({
       name: schemaName,
       prefix: "FHIR",
       url: `${FHIRPATH_ZIG_BASE}/model-${schemaName}.bin`,

--- a/helpers/fhirpath_api_engine.ts
+++ b/helpers/fhirpath_api_engine.ts
@@ -1031,14 +1031,16 @@ export async function evaluateExpressionUsingFhirpathZig(
     }
 
     // Evaluate context expression to get context nodes, or use root
-    let contexts: { path?: string; json: string }[] = [];
+    let contexts: { path?: string; text: string; isXml: boolean }[] = [];
     if (options.contextExpression) {
       try {
         const contextResult = zigEval(options.contextExpression, resourceText, isXml);
         for (const node of contextResult) {
+          // Context results are always JSON (node.data is a JS object)
           contexts.push({
             path: node.meta?.typeName || undefined,
-            json: JSON.stringify(node.data),
+            text: JSON.stringify(node.data),
+            isXml: false,
           });
         }
       } catch (err: any) {
@@ -1048,7 +1050,8 @@ export async function evaluateExpressionUsingFhirpathZig(
         return result;
       }
     } else {
-      contexts.push({ json: resourceText });
+      // No context expression — use the original resource as-is
+      contexts.push({ text: resourceText, isXml });
     }
 
     // Evaluate main expression for each context
@@ -1060,9 +1063,7 @@ export async function evaluateExpressionUsingFhirpathZig(
       };
 
       try {
-        // Context results are always JSON (serialized from first eval)
-        const ctxIsXml = isXml && !options.contextExpression;
-        const evalResult = zigEval(options.expression, ctx.json, ctxIsXml);
+        const evalResult = zigEval(options.expression, ctx.text, ctx.isXml);
 
         for (const node of evalResult) {
           const typeName = node.meta?.typeName || '';

--- a/helpers/fhirpath_api_engine.ts
+++ b/helpers/fhirpath_api_engine.ts
@@ -964,6 +964,141 @@ export function convertOptionsToParametersJavaR5R6(
   return parameters;
 }
 
+// --- fhirpath.zig WASM engine support ---
+
+const FHIRPATH_ZIG_BASE = "https://joshuamandel.com/fhirpath.zig";
+
+let _zigEnginePromise: Promise<any> | null = null;
+let _zigSchemasRegistered: Set<string> = new Set();
+
+async function getZigEngine(): Promise<any> {
+  if (!_zigEnginePromise) {
+    _zigEnginePromise = (async () => {
+      // Dynamic import of the JS wrapper from the deployed site
+      const mod = await import(/* webpackIgnore: true */ `${FHIRPATH_ZIG_BASE}/fhirpath.js`);
+      const FhirPathEngine = mod.FhirPathEngine;
+      const engine = await FhirPathEngine.instantiate(`${FHIRPATH_ZIG_BASE}/fhirpath.wasm`);
+      return engine;
+    })();
+  }
+  return _zigEnginePromise;
+}
+
+async function ensureZigSchema(engine: any, fhirVersion: string): Promise<string> {
+  const version = fhirVersion.toLowerCase();
+  const schemaName = version; // "r4" or "r5"
+  if (!_zigSchemasRegistered.has(schemaName)) {
+    await engine.registerSchemaFromUrl({
+      name: schemaName,
+      prefix: "FHIR",
+      url: `${FHIRPATH_ZIG_BASE}/model-${schemaName}.bin`,
+      isDefault: _zigSchemasRegistered.size === 0,
+    });
+    _zigSchemasRegistered.add(schemaName);
+  }
+  return schemaName;
+}
+
+/**
+ * Evaluate FHIRPath expression using fhirpath.zig WASM engine
+ */
+export async function evaluateExpressionUsingFhirpathZig(
+  options: FhirPathEvaluationOptions,
+  fhirVersion: 'R4' | 'R5' = 'R4'
+): Promise<FhirPathEvaluationResult> {
+  const result: FhirPathEvaluationResult = {
+    results: [],
+    debugTraceData: [],
+    processedByEngine: `fhirpath.zig (${fhirVersion} WASM)`
+  };
+
+  try {
+    const engine = await getZigEngine();
+    const schemaName = await ensureZigSchema(engine, fhirVersion);
+
+    // Set current time
+    engine.setNowDate(new Date());
+
+    const resourceJson = options.resourceJson || '{}';
+
+    // Evaluate context expression to get context nodes, or use root
+    let contexts: { path?: string; json: string }[] = [];
+    if (options.contextExpression) {
+      try {
+        const contextResult = engine.eval({
+          expr: options.contextExpression,
+          json: resourceJson,
+          schema: schemaName,
+        });
+        for (const node of contextResult) {
+          contexts.push({
+            path: node.meta?.typeName || undefined,
+            json: JSON.stringify(node.data),
+          });
+        }
+      } catch (err: any) {
+        result.saveOutcome = CreateOperationOutcome('fatal', 'exception',
+          `Context expression error: ${err.message || err}`);
+        result.showOutcome = true;
+        return result;
+      }
+    } else {
+      contexts.push({ json: resourceJson });
+    }
+
+    // Evaluate main expression for each context
+    for (const ctx of contexts) {
+      const resData: ResultData = {
+        context: ctx.path,
+        result: [],
+        trace: []
+      };
+
+      try {
+        const evalResult = engine.eval({
+          expr: options.expression,
+          json: ctx.json,
+          schema: schemaName,
+        });
+
+        for (const node of evalResult) {
+          const typeName = node.meta?.typeName || '';
+          const data = node.data;
+
+          let value: any;
+          if (data !== null && data !== undefined) {
+            if (typeof data === 'object' && data.value !== undefined && data.unit !== undefined) {
+              // Quantity
+              value = `${data.value} '${data.unit}'`;
+            } else if (typeof data === 'object') {
+              value = JSON.stringify(data, null, 2);
+            } else {
+              value = data;
+            }
+          }
+
+          resData.result.push({
+            type: typeName,
+            value: typeof value === 'string' ? value : JSON.stringify(value),
+          });
+        }
+      } catch (err: any) {
+        result.saveOutcome = CreateOperationOutcome('fatal', 'exception', err.message || String(err));
+        result.showOutcome = true;
+        return result;
+      }
+
+      result.results.push(resData);
+    }
+  } catch (err: any) {
+    result.saveOutcome = CreateOperationOutcome('fatal', 'exception',
+      `Failed to load fhirpath.zig engine: ${err.message || err}`);
+    result.showOutcome = true;
+  }
+
+  return result;
+}
+
 /**
  * Get engine URL and determine if it's a local (non-RESTful) engine
  */
@@ -980,6 +1115,9 @@ export async function getEngineInfo(selectedEngine: IFhirPathEngineDetails): Pro
   if (!selectedEngine.external) {
     if (engineName === "fhirpath.js") {
       return { isLocal: true, requiresSpecialParameterHandling: false, astSupported: true };
+    }
+    if (engineName === "fhirpath.zig") {
+      return { isLocal: true, requiresSpecialParameterHandling: false, astSupported: false };
     }
   }
   
@@ -1014,6 +1152,11 @@ export async function evaluateFhirPathExpression(
   const engineInfo = await getEngineInfo(selectedEngine);
   
   if (engineInfo.isLocal) {
+    const engineName = selectedEngine.name.toLowerCase();
+    if (engineName === "fhirpath.zig") {
+      const fhirVersion = selectedEngine.fhirVersion.toLowerCase() === 'r5' ? 'R5' : 'R4';
+      return await evaluateExpressionUsingFhirpathZig(options, fhirVersion);
+    }
     // Use local fhirpath.js engine
     const fhirVersion = selectedEngine.fhirVersion.toLowerCase() === 'r5' ? 'R5' : 'R4';
     return await evaluateExpressionUsingFhirpathJs(options, fhirVersion as 'R4' | 'R5' | 'R6');

--- a/helpers/fhirpath_api_engine.ts
+++ b/helpers/fhirpath_api_engine.ts
@@ -1020,7 +1020,7 @@ export async function evaluateExpressionUsingFhirpathZig(
     engine.setNowDate(new Date());
 
     const resourceText = options.resourceJson || '{}';
-    const isXml = options.isXmlResource ?? resourceText.trimStart().startsWith('<');
+    const isXml = !!options.isXmlResource;
 
     // Helper: call eval or evalXml depending on input format
     function zigEval(expr: string, input: string, inputIsXml: boolean) {

--- a/helpers/fhirpath_api_engine.ts
+++ b/helpers/fhirpath_api_engine.ts
@@ -977,9 +977,7 @@ async function getZigEngine(): Promise<any> {
       // Dynamic import of the JS wrapper from the deployed site
       const mod = await import(/* webpackIgnore: true */ `${FHIRPATH_ZIG_BASE}/fhirpath.js`);
       const FhirPathEngine = mod.FhirPathEngine;
-      const engine = await FhirPathEngine.instantiate({
-        wasmUrl: `${FHIRPATH_ZIG_BASE}/fhirpath.wasm`,
-      });
+      const engine = await FhirPathEngine.instantiate();
       return engine;
     })();
   }

--- a/helpers/fhirpath_api_engine.ts
+++ b/helpers/fhirpath_api_engine.ts
@@ -1019,17 +1019,22 @@ export async function evaluateExpressionUsingFhirpathZig(
     // Set current time
     engine.setNowDate(new Date());
 
-    const resourceJson = options.resourceJson || '{}';
+    const resourceText = options.resourceJson || '{}';
+    const isXml = resourceText.trimStart().startsWith('<');
+
+    // Helper: call eval or evalXml depending on input format
+    function zigEval(expr: string, input: string, inputIsXml: boolean) {
+      if (inputIsXml) {
+        return engine.evalXml({ expr, xml: input, schema: schemaName });
+      }
+      return engine.eval({ expr, json: input, schema: schemaName });
+    }
 
     // Evaluate context expression to get context nodes, or use root
     let contexts: { path?: string; json: string }[] = [];
     if (options.contextExpression) {
       try {
-        const contextResult = engine.eval({
-          expr: options.contextExpression,
-          json: resourceJson,
-          schema: schemaName,
-        });
+        const contextResult = zigEval(options.contextExpression, resourceText, isXml);
         for (const node of contextResult) {
           contexts.push({
             path: node.meta?.typeName || undefined,
@@ -1043,7 +1048,7 @@ export async function evaluateExpressionUsingFhirpathZig(
         return result;
       }
     } else {
-      contexts.push({ json: resourceJson });
+      contexts.push({ json: resourceText });
     }
 
     // Evaluate main expression for each context
@@ -1055,11 +1060,9 @@ export async function evaluateExpressionUsingFhirpathZig(
       };
 
       try {
-        const evalResult = engine.eval({
-          expr: options.expression,
-          json: ctx.json,
-          schema: schemaName,
-        });
+        // Context results are always JSON (serialized from first eval)
+        const ctxIsXml = isXml && !options.contextExpression;
+        const evalResult = zigEval(options.expression, ctx.json, ctxIsXml);
 
         for (const node of evalResult) {
           const typeName = node.meta?.typeName || '';

--- a/helpers/fhirpath_api_engine.ts
+++ b/helpers/fhirpath_api_engine.ts
@@ -990,8 +990,6 @@ async function ensureZigSchema(engine: any, fhirVersion: string): Promise<string
   if (!_zigSchemasRegistered.has(schemaName)) {
     await engine.registerSchema({
       name: schemaName,
-      prefix: "FHIR",
-      url: `${FHIRPATH_ZIG_BASE}/model-${schemaName}.bin`,
       isDefault: _zigSchemasRegistered.size === 0,
     });
     _zigSchemasRegistered.add(schemaName);

--- a/helpers/fhirpath_api_engine.ts
+++ b/helpers/fhirpath_api_engine.ts
@@ -1020,7 +1020,7 @@ export async function evaluateExpressionUsingFhirpathZig(
     engine.setNowDate(new Date());
 
     const resourceText = options.resourceJson || '{}';
-    const isXml = resourceText.trimStart().startsWith('<');
+    const isXml = options.isXmlResource ?? resourceText.trimStart().startsWith('<');
 
     // Helper: call eval or evalXml depending on input format
     function zigEval(expr: string, input: string, inputIsXml: boolean) {

--- a/types/fhirpath_test_engine.ts
+++ b/types/fhirpath_test_engine.ts
@@ -391,6 +391,31 @@ export let registeredEngines: { [key: string]: IFhirPathEngineDetails } = {
         supportsAST: true,
         supportsXML: false
     },
+    "fhirpath.zig (R4)": {
+        name: "fhirpath.zig",
+        legacyName: "fhirpath.zig (R4)",
+        fhirVersion: "R4",
+        appInsightsEngineName: "fhirpath.zig",
+        publisher: "Joshua Mandel",
+        githubRepo: "https://github.com/jmandel/fhirpath.zig",
+        description: "A Zig/WASM FHIRPath engine running locally in the browser.",
+        external: false,
+        supportsAST: false,
+        supportsXML: false
+    },
+    "fhirpath.zig (R5)": {
+        name: "fhirpath.zig",
+        legacyName: "fhirpath.zig (R5)",
+        fhirVersion: "R5",
+        appInsightsEngineName: "fhirpath.zig",
+        publisher: "Joshua Mandel",
+        githubRepo: "https://github.com/jmandel/fhirpath.zig",
+        description: "A Zig/WASM FHIRPath engine running locally in the browser for FHIR R5.",
+        external: false,
+        supportsAST: false,
+        supportsXML: false
+    },
+
     "CQL (R4)": {
         name: "CQL-Facade",
         legacyName: "CQL (R4)",

--- a/types/fhirpath_test_engine.ts
+++ b/types/fhirpath_test_engine.ts
@@ -401,7 +401,7 @@ export let registeredEngines: { [key: string]: IFhirPathEngineDetails } = {
         description: "A Zig/WASM FHIRPath engine running locally in the browser.",
         external: false,
         supportsAST: false,
-        supportsXML: false
+        supportsXML: true
     },
     "fhirpath.zig (R5)": {
         name: "fhirpath.zig",
@@ -413,7 +413,7 @@ export let registeredEngines: { [key: string]: IFhirPathEngineDetails } = {
         description: "A Zig/WASM FHIRPath engine running locally in the browser for FHIR R5.",
         external: false,
         supportsAST: false,
-        supportsXML: false
+        supportsXML: true
     },
 
     "CQL (R4)": {


### PR DESCRIPTION
## Summary

- Adds **fhirpath.zig** as a local browser-based FHIRPath engine for R4 and R5
- The engine runs as WebAssembly in the browser (no server needed), loading artifacts from `joshuamandel.com/fhirpath.zig`
- [fhirpath.zig](https://github.com/jmandel/fhirpath.zig) is a Zig-based FHIRPath implementation compiled to WASM with a JS wrapper

## What's changed

**`types/fhirpath_test_engine.ts`** — Registers two new engines: `fhirpath.zig (R4)` and `fhirpath.zig (R5)` with `external: false` (browser-local)

**`helpers/fhirpath_api_engine.ts`** — Adds:
- Lazy-loaded singleton WASM engine (loaded once from `joshuamandel.com/fhirpath.zig/fhirpath.wasm`)
- Schema registration for R4/R5 model binaries on first use
- `evaluateExpressionUsingFhirpathZig()` function that evaluates expressions and converts results to `FhirPathEvaluationResult`
- Routing in `getEngineInfo()` and `evaluateFhirPathExpression()` to recognize and dispatch to the zig engine

## How it works

The engine loads via dynamic ESM import from the deployed GitHub Pages site:
1. `fhirpath.js` (JS wrapper) + `fhirpath.wasm` (WASM binary)
2. `model-r4.bin` / `model-r5.bin` (FHIR schema blobs)

These are built and deployed automatically by CI on the fhirpath.zig repo.

## Limitations

- No AST support yet (`supportsAST: false`)
- No XML support (`supportsXML: false`)
- No debug trace support
- Context expressions use a simplified approach (re-evaluating against stringified context nodes)

## Test plan

- [ ] Select "fhirpath.zig (R4)" engine and evaluate basic expressions (e.g., `name.given`)
- [ ] Select "fhirpath.zig (R5)" engine and verify R5 model works
- [ ] Verify error handling for invalid expressions
- [ ] Confirm WASM loads only once across multiple evaluations

🤖 Generated with [Claude Code](https://claude.com/claude-code)