### PR TITLE
Add MaLaC-HD as an additional FML engine

### DIFF
--- a/pages/fml.vue
+++ b/pages/fml.vue
@@ -682,13 +682,15 @@ export default Vue.extend({
         return [
           ".NET (brianpos)",
           "java (HAPI)",
-          "matchbox"
+          "matchbox",
+          "Python (MaLaC-HD)"
         ];
       }
       return [
         ".NET (brianpos)",
         "java (HAPI)",
-        "matchbox" // matchbox now released! Thanks Oliver
+        "matchbox", // matchbox now released! Thanks Oliver
+        "Python (MaLaC-HD)"
       ]
     },
 
@@ -1795,6 +1797,10 @@ group SetEntryData(source src: Patient, target entry)
       else if (this.selectedEngine == "matchbox") {
         url = (await settings.getServerEngineUrl("mapper_server_matchbox"));
         (this as any).$appInsights?.trackEvent({ name: 'evaluate matchbox (map)' });
+      }
+      else if (this.selectedEngine == "Python (MaLaC-HD)") {
+        url = (await settings.getServerEngineUrl("mapper_server_malac_hd"));
+        (this as any).$appInsights?.trackEvent({ name: 'evaluate malac-hd (map)' });
       }
       else {
         (this as any).$appInsights?.trackEvent({ name: 'evaluate .NET (map)' });

--- a/static/config.json
+++ b/static/config.json
@@ -14,6 +14,7 @@
 	"mapper_server": "https://fhir-mapping-lab2.azurewebsites.net/StructureMap/$transform?debug=true",
 	"mapper_server_java": "https://fhirpath-lab-java-g5c4bfdrb8ejamar.australiaeast-01.azurewebsites.net/fhir/$transform?debug=true",
 	"mapper_server_matchbox": "https://test.ahdis.ch/matchbox/fhir/StructureMap/$transform?debug=true",
+	"mapper_server_malac_hd": "https://nikx.eu.pythonanywhere.com/fhir/StructureMap/$transform?debug=true",
 
 	"python_server_r4b": "https://fhirpath.emr.beda.software/fhir/$fhirpath",
 	"python_server_r5": "https://fhirpath.emr.beda.software/fhir/$fhirpath-r5",

--- a/static/config.local.json
+++ b/static/config.local.json
@@ -14,6 +14,7 @@
 	"mapper_server": "https://localhost:7089/StructureMap/$transform?debug=true",
 	"mapper_server_java": "http://localhost:8080/fhir/$transform?debug=true",
 	"mapper_server_matchbox": "https://test.ahdis.ch/matchbox/fhir/StructureMap/$transform?debug=true",
+	"mapper_server_malac_hd": "http://localhost:8000/fhir/StructureMap/$transform?debug=true",
 
 	"python_server_r4b": "http://localhost:8081/fhir/$fhirpath",
 	"python_server_r5": "http://localhost:8081/fhir/$fhirpath-r5",


### PR DESCRIPTION
Adds support for [MaLaC-HD](https://gitlab.com/cdehealth/malac-hd) as an FML engine.

Full debugging support is still lacking and will be added in the future. For the current status see: https://gitlab.com/cdehealth/malac-hd/-/issues/93

For local server setup, see: https://gitlab.com/cdehealth/malac-hd-rest-api

Note that the local setup will only work after malac-hd 1.4.2 is released, which should happen in the next few days.