### PR TITLE
Add Open Health Stack's Kotlin FhirPath engine

### DIFF
--- a/static/config.json
+++ b/static/config.json
@@ -39,5 +39,8 @@
 
 	"ignixa_r4": "https://ignixafhirpath.azurewebsites.net/api/$fhirpath-r4",
 	"ignixa_r5": "https://ignixafhirpath.azurewebsites.net/api/$fhirpath-r5",
-	"ignixa_r6": "https://ignixafhirpath.azurewebsites.net/api/$fhirpath-r6"
+	"ignixa_r6": "https://ignixafhirpath.azurewebsites.net/api/$fhirpath-r6",
+
+  "kotlin_server_r4": "https://kotlin-fhirpath.nawi.ke/fhirpath-r4",
+  "kotlin_server_r5": "https://kotlin-fhirpath.nawi.ke/fhirpath-r5"
 }

--- a/static/config.json
+++ b/static/config.json
@@ -41,6 +41,6 @@
 	"ignixa_r5": "https://ignixafhirpath.azurewebsites.net/api/$fhirpath-r5",
 	"ignixa_r6": "https://ignixafhirpath.azurewebsites.net/api/$fhirpath-r6",
 
-  "kotlin_server_r4": "https://kotlin-fhirpath.nawi.ke/fhirpath-r4",
-  "kotlin_server_r5": "https://kotlin-fhirpath.nawi.ke/fhirpath-r5"
+  "kotlin_server_r4": "http://35.246.242.55/fhirpath-r4",
+  "kotlin_server_r5": "http://35.246.242.55/fhirpath-r5"
 }

--- a/types/fhirpath_test_engine.ts
+++ b/types/fhirpath_test_engine.ts
@@ -399,12 +399,12 @@ export const registeredEngines: { [key: string]: IFhirPathEngineDetails } = {
         supportsXML: false
     },
 
-    "Kotlin (Open Health Stack)": {
+    "Kotlin FHIRPath R4 (Open Health Stack)": {
       name: "kotlin-fhirpath",
       legacyName: "kotlin-fhirpath (Open Health Stack)",
       fhirVersion: "R4",
       appInsightsEngineName: "Kotlin",
-      publisher: "Open Health Stack",
+      publisher: "Open Health Stack Foundation",
       configSetting: "kotlin_server_r4",
       githubRepo: "https://github.com/ohs-foundation/kotlin-fhirpath",
       description: "A Kotlin implementation of FHIRPath by Open Health Stack.",
@@ -413,7 +413,7 @@ export const registeredEngines: { [key: string]: IFhirPathEngineDetails } = {
       supportsXML: false
     },
 
-    "Kotlin R5 (Open Health Stack)": {
+    "Kotlin FHIRPath R5 (Open Health Stack)": {
       name: "kotlin-fhirpath",
       legacyName: "kotlin-fhirpath (Open Health Stack)",
       fhirVersion: "R5",

--- a/types/fhirpath_test_engine.ts
+++ b/types/fhirpath_test_engine.ts
@@ -27,7 +27,7 @@ export interface IFhirPathEngineDetails {
 
     /** True if this is an external engine (i.e. not running in the same environment as the FHIRPath Lab application */
     external?: boolean;
-   
+
     /** The engine can provide an AST for the expression (otherwise will display that it's not supported) */
     supportsAST: boolean;
 
@@ -317,7 +317,7 @@ export const registeredEngines: { [key: string]: IFhirPathEngineDetails } = {
         supportsAST: true,
         supportsXML: false
     },
-    
+
     "toolbox-go (R4)": {
         name: "toolbox-go",
         legacyName: "toolbox-go (R4)",
@@ -397,6 +397,34 @@ export const registeredEngines: { [key: string]: IFhirPathEngineDetails } = {
         external: true,
         supportsAST: true,
         supportsXML: false
+    },
+
+    "Kotlin (Open Health Stack)": {
+      name: "kotlin-fhirpath",
+      legacyName: "kotlin-fhirpath (Open Health Stack)",
+      fhirVersion: "R4",
+      appInsightsEngineName: "Kotlin",
+      publisher: "Open Health Stack",
+      configSetting: "kotlin_server_r4",
+      githubRepo: "https://github.com/ohs-foundation/kotlin-fhirpath",
+      description: "A Kotlin implementation of FHIRPath by Open Health Stack.",
+      external: true,
+      supportsAST: false,
+      supportsXML: false
+    },
+
+    "Kotlin R5 (Open Health Stack)": {
+      name: "kotlin-fhirpath",
+      legacyName: "kotlin-fhirpath (Open Health Stack)",
+      fhirVersion: "R5",
+      appInsightsEngineName: "Kotlin",
+      publisher: "Open Health Stack",
+      configSetting: "kotlin_server_r5",
+      githubRepo: "https://github.com/ohs-foundation/kotlin-fhirpath",
+      description: "A Kotlin implementation of FHIRPath for FHIR R5 by Open Health Stack.",
+      external: true,
+      supportsAST: false,
+      supportsXML: false
     },
 };
 


### PR DESCRIPTION
Adds OHS [FhirPath](https://github.com/ohs-foundation/kotlin-fhirpath) engine, with the server api implementation https://github.com/ohs-foundation/kotlin-fhirpath-server